### PR TITLE
Improve "rainbow" emergence; fix minor issues

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -12,6 +12,7 @@ html, body {
   position: relative;
   width: 100vmin;
   height: 100vmin;
+  overflow: hidden;
   padding: 5%;
   top: 50%;
   transform: translate(-50%, -50%);
@@ -305,25 +306,37 @@ html, body {
     .container section:nth-of-type(3) {
       grid-column: span 4;
       grid-row: span 2;
-      overflow-y: hidden; }
+      overflow: hidden; }
       .container section:nth-of-type(3) div {
         position: relative;
         width: 100%;
         height: 100%;
         overflow: hidden;
         background: transparent;
-        animation: rotate 3s ease-in-out; }
+        animation: rotate 3s ease-in-out;
+        transform-origin: bottom center; }
 
 @keyframes rotate {
   0% {
-    transform: translate(-150%, 50%) rotate(-90deg); }
+    transform: rotate(-180deg); }
   100% {
-    transform: translate(0, 0) rotate(0deg); } }
+    transform: rotate(0deg); } }
         .container section:nth-of-type(3) div:after {
           position: absolute;
-          box-shadow: 0 0 0 1vmin #FF3BA7, 0 0 0 2vmin #CC42A2, 0 0 0 3vmin #9f49ac, 0 0 0 4vmin #476EAF, 0 0 0 5vmin #179067, 0 0 0 6vmin #50B517, 0 0 0 7vmin #9ED110, 0 0 0 8vmin #EDE604, 0 0 0 9vmin #FFCC00, 0 0 0 10vmin #FEAC00, 0 0 0 11vmin #FF8100, 0 0 0 12vmin #FF5800;
+          box-shadow: 0 0 0 1vmin #FF3BA7,
+ 0 0 0 2vmin #CC42A2,
+ 0 0 0 3vmin #9f49ac,
+ 0 0 0 4vmin #476EAF,
+ 0 0 0 5vmin #179067,
+ 0 0 0 6vmin #50B517,
+ 0 0 0 7vmin #9ED110,
+ 0 0 0 8vmin #EDE604,
+ 0 0 0 9vmin #FFCC00,
+ 0 0 0 10vmin #FEAC00,
+ 0 0 0 11vmin #FF8100,
+ 0 0 0 12vmin #FF5800;
           width: 65%;
-          height: 150%;
+          height: 136.44%;
           top: 110%;
           transform: translate(-50%, -50%);
           left: 50%;


### PR DESCRIPTION
* Make "rainbow" element emerge with rotation;
* fix "rainbow" animation transform origin;
* fix "rainbow" height (calculations based on container width/height ratio);
* prevent scrollbar from appearing by adding `overflow: hidden;`.

Notes: for some reason this diff for shadow definition https://github.com/ololoepepe/rainbow-tricks/commit/12e2474fe606e59442f3f3cf2ac4b7440ba09b89#diff-5ea401737dc83447750193b5967bad95L324 was generated, though no changes were actually made to that line. May be skipped.